### PR TITLE
Convert static methods to non-static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.3
+* Update: Updated for MediaWiki >= 1.38 (z929669)
+* Still works for MediaWiki >= 1.35
+
+## 1.0.2
+* Update: Updated for IPB 4.x (karu)
+* Update: Changed validations, updated for MW 1.35 (Jordan Songer)
+
 ## 1.0.1
 * Bugfix: Users could not edit their signature
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 IPBAuthLogin
 ============
 
-IPBAuthLogin is a plugin for MediaWiki 1.35 and up which integrates MediaWiki with an [Invision Power Board and Invision Community](https://invisioncommunity.com) forum's user database. By enabling the extension, it is possible to log into the MediaWiki installation using IPB user accounts. The extension creates local user accounts on MediaWiki, which are always authenticated though this extension.
+IPBAuthLogin is a plugin for MediaWiki 1.38 and up which integrates MediaWiki with an [Invision Power Board and Invision Community](https://invisioncommunity.com) forum's user database. By enabling the extension, it is possible to log into the MediaWiki installation using IPB user accounts. The extension creates local user accounts on MediaWiki, which are always authenticated though this extension.
 
 As IPB usernames are not case sensitive, extension converts any username into a canonical form, to avoid duplicate local accounts being created for the same user.
 
@@ -9,9 +9,9 @@ Requirements
 ------------
 
 * MediaWiki 1.35+
-* Invision Power Board 3 / IPS Community 4
-* MySQL database for IPB
-* PHP 7.0+ (Untested for PHP 5.6 and older)
+* Invision Power Board 3.x | IPS Community 4.x
+* MySQL/MariaDB
+* PHP 7.0+ (PHP <=5.6: untested & PHP 8.0: tested)
 * MySQLi PHP extension
 
 Documentation

--- a/extension.json
+++ b/extension.json
@@ -1,13 +1,13 @@
 {
     "name": "IPBLoginAuth",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": "Frédéric Hannes",
     "url": "https://www.mediawiki.org/wiki/Extension:IPBAuthLogin",
     "descriptionmsg": "ipbloginauth-desc",
     "license-name": "GPLv3",
     "type": "auth",
     "requires": {
-        "MediaWiki": ">= 1.35.0"
+        "MediaWiki": ">=1.35.0"
     },
     "ConfigRegistry": {
         "ipbloginauth": "GlobalVarConfig::newInstance"
@@ -42,5 +42,6 @@
         "IPBGroupMap": {
             "sysop": 4
         }
-    }
+    },
+	"manifest_version": 1
 }

--- a/extension.json
+++ b/extension.json
@@ -43,5 +43,5 @@
             "sysop": 4
         }
     },
-	"manifest_version": 1
+    "manifest_version": 1
 }

--- a/includes/IPBAuth.php
+++ b/includes/IPBAuth.php
@@ -135,9 +135,9 @@ class IPBAuth
                     if ($stmt->num_rows == 1) {
                         $stmt->bind_result($name);
                         if ($stmt->fetch()) {
-							// Updated static method to be non-static
-                        	$userNameUtils = MediaWikiServices::getInstance()->getUserNameUtils();
-                        	$username = $userNameUtils->getCanonical( $username, UserNameUtils::RIGOR_CREATABLE ) ?: $username;
+                            // Updated static method to be non-static
+                            $userNameUtils = MediaWikiServices::getInstance()->getUserNameUtils();
+                            $username = $userNameUtils->getCanonical( $username, UserNameUtils::RIGOR_CREATABLE ) ?: $username;
                             if ($username) {
                                 return $username;
                             }
@@ -225,13 +225,13 @@ class IPBAuth
                             $groupmap = $cfg->get('IPBGroupMap');
                             if (is_array($groupmap)) {
                                 foreach ($groupmap as $ug_wiki => $ug_ipb) {
-                                	// Updated static method to be non-static
-									$userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
-									$user_has_ug = in_array($ug_wiki, $userGroupManager->getUserEffectiveGroups( $user )) ?: $user_has_ug;
+                                    // Updated static method to be non-static
+                                    $userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
+                                    $user_has_ug = in_array($ug_wiki, $userGroupManager->getUserEffectiveGroups( $user )) ?: $user_has_ug;
                                     if (!empty(array_intersect((array)$ug_ipb, $groups)) && !$user_has_ug) {
-										$userGroupManager->addUserToGroup( $user, $ug_wiki );
+                                        $userGroupManager->addUserToGroup( $user, $ug_wiki );
                                     } elseif (empty(array_intersect((array)$ug_ipb, $groups)) && $user_has_ug) {
-										$userGroupManager->removeUserFromGroup( $user, $ug_wiki );
+                                        $userGroupManager->removeUserFromGroup( $user, $ug_wiki );
                                     }
                                 }
                             }

--- a/includes/IPBAuth.php
+++ b/includes/IPBAuth.php
@@ -20,8 +20,10 @@
 namespace IPBLoginAuth;
 
 use ConfigFactory;
-use User;
-use UserGroupManager;
+
+use MediaWiki\User\UserNameUtils;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\User\UserGroupManager;
 
 class IPBAuth
 {
@@ -88,7 +90,7 @@ class IPBAuth
     }
 
     /**
-     * Normalizes a username based on the usernames stored in teh forum database.
+     * Normalizes a username based on the usernames stored in the forum database
      *
      * @param $username
      * @return string
@@ -133,7 +135,9 @@ class IPBAuth
                     if ($stmt->num_rows == 1) {
                         $stmt->bind_result($name);
                         if ($stmt->fetch()) {
-                            $username = User::getCanonicalName($name, 'creatable');
+							// Updated static method to be non-static
+                        	$userNameUtils = MediaWikiServices::getInstance()->getUserNameUtils();
+                        	$username = $userNameUtils->getCanonical( $username, UserNameUtils::RIGOR_CREATABLE ) ?: $username;
                             if ($username) {
                                 return $username;
                             }
@@ -150,7 +154,7 @@ class IPBAuth
     }
 
     /**
-     * Updates a \User object with data from the IPB forum database.
+     * Updates a \User object with data from the IPB forum database
      *
      * @param $user
      */
@@ -221,11 +225,13 @@ class IPBAuth
                             $groupmap = $cfg->get('IPBGroupMap');
                             if (is_array($groupmap)) {
                                 foreach ($groupmap as $ug_wiki => $ug_ipb) {
-                                    $user_has_ug = in_array($ug_wiki, UserGroupManager::getUserEffectiveGroups($user));
+                                	// Updated static method to be non-static
+									$userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
+									$user_has_ug = in_array($ug_wiki, $userGroupManager->getUserEffectiveGroups( $user )) ?: $user_has_ug;
                                     if (!empty(array_intersect((array)$ug_ipb, $groups)) && !$user_has_ug) {
-                                        UserGroupManager::addUserToGroup($user,$ug_wiki);
+										$userGroupManager->addUserToGroup( $user, $ug_wiki );
                                     } elseif (empty(array_intersect((array)$ug_ipb, $groups)) && $user_has_ug) {
-                                        UserGroupManager::removeUserFromGroup($user,$ug_wiki);
+										$userGroupManager->removeUserFromGroup( $user, $ug_wiki );
                                     }
                                 }
                             }
@@ -242,7 +248,7 @@ class IPBAuth
     }
 
     /**
-     * Verifies whether a username is already in use in the IPB forum database.
+     * Verifies whether a username is already in use in the IPB forum database
      *
      * @param $username
      * @return bool
@@ -284,7 +290,7 @@ class IPBAuth
     }
 
     /**
-     * Verifies if a supplied password matches the password hash in the IPB database.
+     * Verifies if a supplied password matches the password hash in the IPB database
      *
      * @param $password
      * @param $hash

--- a/includes/auth/IPBAuthenticationProvider.php
+++ b/includes/auth/IPBAuthenticationProvider.php
@@ -29,7 +29,9 @@ use MediaWiki\Auth\PrimaryAuthenticationProvider;
 
 use Hooks;
 use StatusValue;
-use User;
+
+use MediaWiki\User\UserNameUtils;
+use MediaWiki\MediaWikiServices;
 
 class IPBAuthenticationProvider extends AbstractPrimaryAuthenticationProvider
 {
@@ -121,7 +123,9 @@ class IPBAuthenticationProvider extends AbstractPrimaryAuthenticationProvider
                         }
                     }
                     if ($success) {
-                        $username = User::getCanonicalName($name, 'creatable');
+						// Updated static method to be non-static
+                        $userNameUtils = MediaWikiServices::getInstance()->getUserNameUtils();
+                        $username = $userNameUtils->getCanonical( $username, UserNameUtils::RIGOR_CREATABLE ) ?: $username;
                         if (!$username) {
                             $username = $req->username;
                         }
@@ -156,7 +160,7 @@ class IPBAuthenticationProvider extends AbstractPrimaryAuthenticationProvider
 
     public static function onUserLoggedIn($user)
     {
-        // When a user logs in, update the local account with information from the IPB database.
+        // When a user logs in, update the local account with information from the IPB database
         IPBAuth::updateUser($user);
     }
 

--- a/includes/auth/IPBAuthenticationProvider.php
+++ b/includes/auth/IPBAuthenticationProvider.php
@@ -123,7 +123,7 @@ class IPBAuthenticationProvider extends AbstractPrimaryAuthenticationProvider
                         }
                     }
                     if ($success) {
-						// Updated static method to be non-static
+                        // Updated static method to be non-static
                         $userNameUtils = MediaWikiServices::getInstance()->getUserNameUtils();
                         $username = $userNameUtils->getCanonical( $username, UserNameUtils::RIGOR_CREATABLE ) ?: $username;
                         if (!$username) {

--- a/includes/auth/IPBAuthenticationRequest.php
+++ b/includes/auth/IPBAuthenticationRequest.php
@@ -23,5 +23,5 @@ use MediaWiki\Auth\PasswordAuthenticationRequest;
 
 class IPBAuthenticationRequest extends PasswordAuthenticationRequest
 {
-
+	// Authentication request is not implemented
 }


### PR DESCRIPTION
The static functions are no longer compatible with a few of the methods used. Example: `User::getCanonicalName()`

I discovered this when upgrading our wiki (1.35.1) to 1.39.1, and this plugin is essential for our members gaining access to our otherwise closed wiki. The changes I've made correct these issues; although, there are likely better ways to resolve. I'm not a coder by profession, just a hack.

Example:
```
$username = User::getCanonicalName($name, 'creatable');
```
becomes:
```
$userNameUtils = MediaWikiServices::getInstance()->getUserNameUtils();
$username = $userNameUtils->getCanonical( $username, UserNameUtils::RIGOR_CREATABLE ) ?: $username;
```